### PR TITLE
Replace database_cleaner with database_cleaner-active_record

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ end
 
 group :test do
   gem "capybara"
-  gem "database_cleaner"
+  gem "database_cleaner-active_record"
   gem "factory_bot_rails"
   gem "minitest-spec-rails"
   gem "mocha", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,10 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
-    database_cleaner (1.8.5)
+    database_cleaner-active_record (2.0.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.10.0)
@@ -302,7 +305,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara
-  database_cleaner
+  database_cleaner-active_record
   factory_bot_rails
   formtastic
   googlebooks


### PR DESCRIPTION
We should use the gem for the ORM we need, instead of installing the `database_cleaner` gem directly. This also bumps the version.