### PR TITLE
Minor accessibility fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ An easier way to keep track of the books on your office bookshelf.
 * Keeps track of multiple copies of each book
 * Looks up book details from Google Books and Openlibrary based on the ISBN
 
-![](http://jordanhatch.github.com/anthology/img/screenshot.png)
-
 ## Getting started
 
     bundle install

--- a/app/assets/stylesheets/books.scss
+++ b/app/assets/stylesheets/books.scss
@@ -45,7 +45,7 @@ ul.books {
     font-size: 0.75em;
   }
 
-  span[rel='author'] { display: block; font-size: 0.8em; padding-top: 0.5em; color: #c4d3d8; }
+  span[rel='author'] { display: block; font-size: 0.8em; padding-top: 0.5em; color: #000; }
 }
 
 section.single_book {

--- a/app/assets/stylesheets/start.scss
+++ b/app/assets/stylesheets/start.scss
@@ -4,7 +4,7 @@
   .greeting {
     margin: 1rem;
 
-    span { color: #777; }
+    span { color: #737373; }
     h1, span { display: inline-block; margin: 0 0 0.25em; vertical-align: baseline; }
 
     @media (min-width: 825px){

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title><%= library_title %></title>
   <%= stylesheet_link_tag    "application", :media => "all" %>

--- a/public/404.html
+++ b/public/404.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>The page you were looking for doesn't exist (404)</title>
   <style type="text/css">

--- a/public/422.html
+++ b/public/422.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>The change you wanted was rejected (422)</title>
   <style type="text/css">

--- a/public/500.html
+++ b/public/500.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>We're sorry, but something went wrong (500)</title>
   <style type="text/css">


### PR DESCRIPTION
**Give all `<html>` elements a lang attribute**
This matters because screen readers check the language. The site is currently completely unusable with any form of screen reader, so this won't have any benefit yet but it's a first step...

**Fix two places with insufficient colour contrast**
There are more places than this with insufficient colour contrast, but this fixes the issue in two places:
- The author's name on the placeholder book covers (the ones shown when we can't get an image of the real cover)
- The line of welcome text telling you how many books you have on loan

Plus a tiny change to remove a broken link from the README.md