### PR TITLE
Bump rack to fix 2 security vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-protection (2.2.0)
       rack
     rack-test (1.1.0)


### PR DESCRIPTION
This bumps rack to avoid
- [Possible shell escape sequence injection vulnerability in Rack](https://github.com/alphagov/anthology/security/dependabot/14)
- [Denial of Service Vulnerability in Rack Multipart Parsing](https://github.com/alphagov/anthology/security/dependabot/13)