### PR TITLE
Standardise test styles slightly by removing Shoulda syntax

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,6 +61,4 @@ Rails.application.configure do
   config.after_initialize do
     PaperTrail.enabled = false
   end
-
-  config.minitest_spec_rails.mini_shoulda = true
 end

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -5,7 +5,7 @@ describe BooksController do
     stub_user_session
   end
 
-  context "book list" do
+  describe "listing the books on the index page" do
     setup do
       @books = [
         FactoryBot.create(:book, title: "Harry Potter and the Chamber of Secrets"),
@@ -14,47 +14,47 @@ describe BooksController do
       ]
     end
 
-    should "return a successful response" do
+    it "returns a successful response" do
       get :index
       assert response.successful?
     end
 
-    should "initialize a list of books" do
+    it "initializes a list of books" do
       get :index
       assert_equal 3, assigns(:books).length
       assert_equal @books.map(&:title).sort, assigns(:books).map(&:title).sort
     end
 
-    should "render the index view" do
+    it "renders the index view" do
       get :index
       assert_template "index"
     end
 
-    context "searching for a book" do
-      should "return results for a title search" do
+    describe "searching for a book" do
+      it "returns results for a title search" do
         get :index, params: { q: "Harry" }
         assert_equal "Harry Potter and the Chamber of Secrets", assigns(:books).first.title
       end
 
-      should "not return results when there are no matches" do
+      it "does not return results when there are no matches" do
         get :index, params: { q: "Lord Voldermort" }
         assert_equal 0, assigns(:books).length
       end
     end
   end
 
-  context "new book form" do
-    should "render the form" do
+  describe "new book form" do
+    it "renders the form" do
       get :new
       assert_template "new"
     end
 
-    should "return a successful response" do
+    it "returns a successful response" do
       get :new
       assert response.successful?
     end
 
-    should "assign an new book object" do
+    it "assigns an new book object" do
       get :new
 
       assert_instance_of Book, assigns(:book)
@@ -62,17 +62,17 @@ describe BooksController do
     end
   end
 
-  context "a single book" do
+  describe "viewing a single book" do
     setup do
       @book = FactoryBot.create(:book)
     end
 
-    should "return a successful response" do
+    it "returns a successful response" do
       get :show, params: { id: @book.id }
       assert response.successful?
     end
 
-    should "load the book details" do
+    it "loads the book details" do
       get :show, params: { id: @book.id }
 
       assert_equal @book.id, assigns(:book).id
@@ -80,7 +80,7 @@ describe BooksController do
       assert_equal @book.author, assigns(:book).author
     end
 
-    should "render the show template" do
+    it "renders the show template" do
       get :show, params: { id: @book.id }
 
       assert_template "books/show"

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -5,41 +5,41 @@ describe RootController do
     stub_user_session
   end
 
-  context "the start page" do
+  describe "the start page" do
     setup do
       # create some books
       FactoryBot.create_list(:book, 8)
     end
 
-    should "be a successful request" do
+    it "returns a successful response" do
       get :start
 
       assert response.successful?
     end
 
-    should "load eight books to display to the user" do
+    it "loads eight books to display to the user" do
       get :start
 
       assert_equal 8, assigns(:books).count
       assert_instance_of Book, assigns(:books).first
     end
 
-    should "load 3 recently added copies to display to the user" do
+    it "loads 3 recently added copies to display to the user" do
       get :start
 
       assert_equal 3, assigns(:recently_added_copies).count
       assert_instance_of Copy, assigns(:recently_added_copies).first
     end
 
-    should "render the start template" do
+    it "renders the start template" do
       get :start
 
       assert_template "start"
     end
   end
 
-  context "the library csv page" do
-    should "generates a CSV file with a row for each book" do
+  describe "the library csv page" do
+    it "generates a CSV file with a row for each book" do
       FactoryBot.create(:book, id: 1, title: "Book 1", author: "A. One", isbn: "1")
       FactoryBot.create(:book, id: 2, title: "Book 2", author: "A. Two", isbn: "2")
 

--- a/test/integration/book_actions_test.rb
+++ b/test/integration/book_actions_test.rb
@@ -1,17 +1,17 @@
 require "integration_test_helper"
 
 class BookActionsTest < ActionDispatch::IntegrationTest
-  context "as a signed in user" do
+  describe "a signed in user" do
     setup do
       sign_in_user
     end
 
-    context "given a book exists" do
+    describe "given a book exists" do
       setup do
         @book = FactoryBot.create(:book, title: "The Wind in the Willows", author: "Kenneth Grahame", google_id: "mock-google-id")
       end
 
-      should "see the book details" do
+      it "shows the book details" do
         visit "/books/#{@book.id}"
 
         within ".cover" do
@@ -24,7 +24,7 @@ class BookActionsTest < ActionDispatch::IntegrationTest
         end
       end
 
-      should "see copies" do
+      it "shows a book's copies" do
         visit "/books/#{@book.id}"
 
         assert page.has_content?("1 copy")
@@ -35,7 +35,7 @@ class BookActionsTest < ActionDispatch::IntegrationTest
         end
       end
 
-      should "see the book history for a book with changes" do
+      it "displays the book history for a book with changes" do
         with_versioning do
           PaperTrail.request.whodunnit = FactoryBot.create(:user, name: "Mr Toad").id.to_s
           @book.update!(title: "Goodnight Mister Tom")
@@ -52,7 +52,7 @@ class BookActionsTest < ActionDispatch::IntegrationTest
         end
       end
 
-      should "see a message instead of book history for a book without any changes" do
+      it "displays a message instead of book history for a book without any changes" do
         visit "/books/#{@book.id}"
         click_on "See revision history"
 

--- a/test/integration/copy_actions_test.rb
+++ b/test/integration/copy_actions_test.rb
@@ -1,17 +1,17 @@
 require "integration_test_helper"
 
 class CopyActionsTest < ActionDispatch::IntegrationTest
-  context "as a signed in user" do
+  describe "a signed in user" do
     setup do
       sign_in_user
     end
 
-    context "given an available copy exists" do
+    describe "given an available copy exists" do
       setup do
         @copy = FactoryBot.create(:copy, book_reference: "123")
       end
 
-      should "render the copy page" do
+      it "renders the copy page" do
         visit "/copy/123"
 
         assert page.has_content?("123")
@@ -20,7 +20,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
         assert page.has_content?("Borrow")
       end
 
-      should "allow the book to be borrowed" do
+      it "allows the book to be borrowed" do
         visit "/copy/123"
         click_on "Borrow"
 
@@ -30,19 +30,19 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
         assert page.has_content?("since #{Time.zone.today.strftime('%b %d, %Y')}")
       end
 
-      should "not display the loan history section if no previous loans" do
+      it "does not display the loan history section if there are no previous loans" do
         visit "/copy/123"
 
         assert page.has_no_content?("Loan history")
       end
 
-      should "link to the book page" do
+      it "links to the book page" do
         visit "/copy/123"
         assert page.has_link?("See all copies of this book", href: "/books/#{@copy.book.id}")
       end
 
-      context "given a shelf exists" do
-        should "allow shelf to be set" do
+      describe "given a shelf exists" do
+        it "allows the shelf to be set" do
           visit "/copy/123"
           within ".shelf" do
             click_link "set"
@@ -61,13 +61,13 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
       end
     end
 
-    context "given a copy is on loan to the signed in user" do
+    describe "given a copy is on loan to the signed in user" do
       setup do
         @copy = FactoryBot.create(:copy, book_reference: "123")
         @copy.borrow(signed_in_user)
       end
 
-      should "render the copy page" do
+      it "renders the copy page" do
         visit "/copy/123"
 
         assert page.has_content?("123")
@@ -76,7 +76,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
         assert page.has_content?("Return")
       end
 
-      should "allow the book to be returned" do
+      it "allows the book to be returned" do
         visit "/copy/123"
         select "7th floor", from: "Return to"
         click_on "Return"
@@ -90,14 +90,14 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
       end
     end
 
-    context "given a copy is on loan to another user" do
+    describe "given a copy is on loan to another user" do
       setup do
         @another_user = FactoryBot.create(:user, name: "O'Brien")
         @copy = FactoryBot.create(:copy, book_reference: "123")
         @copy.borrow(@another_user)
       end
 
-      should "render the copy page" do
+      it "renders the copy page" do
         visit "/copy/123"
 
         assert page.has_content?("123")
@@ -106,7 +106,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
         assert page.has_content?("since #{Time.zone.today.strftime('%b %d, %Y')}")
       end
 
-      should "allow the book to be returned" do
+      it "allows the book to be returned" do
         visit "/copy/123"
         click_on "Return"
 
@@ -121,7 +121,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
       end
     end
 
-    context "given a copy which has been borrowed multiple times" do
+    describe "given a copy which has been borrowed multiple times" do
       setup do
         @copy = FactoryBot.create(:copy, book_reference: "53")
 
@@ -135,7 +135,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
         ]
       end
 
-      should "display a list of previous loans" do
+      it "displays a list of previous loans" do
         visit "/copy/53"
 
         assert page.has_selector?("h3", text: "Loan history")
@@ -149,7 +149,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
         ], rows
       end
 
-      should "link the name previous loaning user to their profile" do
+      it "links the name previous loaning user to their profile" do
         visit "/copy/53"
 
         assert page.has_link?("Julia", href: "/user/#{@user1.id}")

--- a/test/integration/start_page_test.rb
+++ b/test/integration/start_page_test.rb
@@ -1,12 +1,12 @@
 require "integration_test_helper"
 
 class StartPageTest < ActionDispatch::IntegrationTest
-  context "as a signed in user" do
+  describe "as a signed in user" do
     setup do
       sign_in_user
     end
 
-    should "load the start page" do
+    it "loads the start page" do
       FactoryBot.create_list(:book, 8)
 
       visit "/"
@@ -15,14 +15,14 @@ class StartPageTest < ActionDispatch::IntegrationTest
       assert page.has_content?("You have 0 books on loan")
     end
 
-    should "update the number of items on loan" do
+    it "updates the number of items on loan" do
       FactoryBot.create_list(:loan, 5, user: signed_in_user)
 
       visit "/"
       assert page.has_content?("You have 5 books on loan")
     end
 
-    should "allow the user to look up a valid copy by id" do
+    it "allows the user to look up a valid copy by id" do
       FactoryBot.create(:copy, book_reference: "123")
 
       visit "/"
@@ -35,7 +35,7 @@ class StartPageTest < ActionDispatch::IntegrationTest
       assert "/copy/123", current_path
     end
 
-    should "show an error when a user attempts to look up an invalid copy id" do
+    it "shows an error when a user attempts to look up an invalid copy id" do
       visit "/"
 
       within ".copy-lookup" do
@@ -47,7 +47,7 @@ class StartPageTest < ActionDispatch::IntegrationTest
       assert page.has_content?("Copy 999 couldn't be found")
     end
 
-    should "display recently added copies added to the library" do
+    it "displays recently added copies added to the library" do
       @book = FactoryBot.create(:book, title: "The Lion, the Witch and the Wardrobe")
       @older_copies = FactoryBot.create_list(:copy, 10)
       @copy = FactoryBot.create(:copy, book_reference: "123", book: @book)
@@ -61,7 +61,7 @@ class StartPageTest < ActionDispatch::IntegrationTest
       end
     end
 
-    should "display recent loans from the library" do
+    it "displays recent loans from the library" do
       copies_on_loan = FactoryBot.create_list(:copy_on_loan, 5)
 
       visit "/"

--- a/test/lib/book_metadata_lookup_test.rb
+++ b/test/lib/book_metadata_lookup_test.rb
@@ -16,8 +16,8 @@ class BookMetadataLookupTest < ActiveSupport::TestCase
     })
   end
 
-  context ".find_by_isbn" do
-    should "call both APIs with the given ISBN number" do
+  describe ".find_by_isbn" do
+    it "calls both APIs with the given ISBN number" do
       isbn = "0995739013"
 
       GoogleBooks.expects(:search).with("isbn:#{isbn}").returns([@google_data])
@@ -27,8 +27,8 @@ class BookMetadataLookupTest < ActiveSupport::TestCase
     end
   end
 
-  context ".format_response" do
-    should "raise BookNotFound if sources does not contain google or openlibrary keys" do
+  describe ".format_response" do
+    it "raises BookNotFound if sources does not contain google or openlibrary keys" do
       sources = { "another library" => "book" }
 
       assert_raises BookMetadataLookup::BookNotFound do
@@ -36,7 +36,7 @@ class BookMetadataLookupTest < ActiveSupport::TestCase
       end
     end
 
-    should "return book data when only google data is present" do
+    it "returns book data when only google data is present" do
       sources = { google: @google_data, openlibrary: nil }
 
       expected_result = { google_id: "1", title: "Code Complete", author: "Steve McConnell", openlibrary_id: nil }
@@ -44,7 +44,7 @@ class BookMetadataLookupTest < ActiveSupport::TestCase
       assert_equal expected_result, BookMetadataLookup.format_response(sources)
     end
 
-    should "return book data when only openlibrary data is present" do
+    it "returns book data when only openlibrary data is present" do
       sources = { google: nil, openlibrary: @openlibrary_data }
 
       expected_result = {
@@ -57,7 +57,7 @@ class BookMetadataLookupTest < ActiveSupport::TestCase
       assert_equal expected_result, BookMetadataLookup.format_response(sources)
     end
 
-    should "use the title and author from google when both data sources are present" do
+    it "uses the title and author from google when both data sources are present" do
       sources = { google: @google_data, openlibrary: @openlibrary_data }
 
       expected_result = {
@@ -71,14 +71,14 @@ class BookMetadataLookupTest < ActiveSupport::TestCase
     end
   end
 
-  context ".format_openlibrary_authors" do
-    should "get the name of a single author" do
+  describe ".format_openlibrary_authors" do
+    it "gets the name of a single author" do
       author = [{ "url" => "http://openlibrary.org/authors/OL1/Ethan_Brown", "name" => "Ethan Brown" }]
 
       assert_equal "Ethan Brown", BookMetadataLookup.format_openlibrary_authors(author)
     end
 
-    should "get the names of multiple authors" do
+    it "gets the names of multiple authors" do
       authors = [
         { "url" => "http://openlibrary.org/authors/OL1/Agatha_Henderson", "name" => "Agatha Henderson" },
         { "url" => "http://openlibrary.org/authors/OL2/Jane_E._Reed", "name" => "Jane E. Reed" },

--- a/test/models/book_test.rb
+++ b/test/models/book_test.rb
@@ -1,22 +1,22 @@
 require "test_helper"
 
 describe Book do
-  context "creating a book" do
-    should "require an author" do
+  describe "creating a book" do
+    it "requires an author" do
       book = Book.new
 
       assert_not book.valid?
       assert_equal ["can't be blank"], book.errors[:author]
     end
 
-    should "require a title" do
+    it "requires a title" do
       book = Book.new
 
       assert_not book.valid?
       assert_equal ["can't be blank"], book.errors[:title]
     end
 
-    should "require a unique ISBN number" do
+    it "requires a unique ISBN number" do
       Book.create!(title: "The Sign of the Four", author: "Conan Doyle", isbn: "abc 123")
       book_two = Book.new(title: "A Study in Scarlet", author: "Conan Doyle", isbn: "ABC-123")
 
@@ -24,13 +24,13 @@ describe Book do
       assert_equal ["has already been taken"], book_two.errors[:isbn]
     end
 
-    should "create an initial copy upon creation" do
+    it "creates an initial copy upon creation" do
       book = FactoryBot.create(:book)
 
       assert_equal 1, book.copies.count
     end
 
-    should "set the creating user" do
+    it "sets the creating user" do
       user = FactoryBot.create(:user)
       book = FactoryBot.create(:book, created_by: user)
 
@@ -38,20 +38,20 @@ describe Book do
     end
   end
 
-  context "editing a book" do
-    context "changing the ISBN" do
+  describe "editing a book" do
+    describe "changing the ISBN" do
       setup do
         @book = FactoryBot.create(:book)
       end
 
-      should "persist the new isbn" do
+      it "persists the new isbn" do
         @book.update!(isbn: "0140817743")
         @book.reload
 
         assert_equal "0140817743", @book.isbn
       end
 
-      should "strip whitespace and dashes from the isbn" do
+      it "strips whitespace and dashes from the isbn" do
         @book.update!(isbn: "0 1408-177-43")
         @book.reload
 

--- a/test/models/copy_test.rb
+++ b/test/models/copy_test.rb
@@ -5,13 +5,13 @@ describe Copy do
     @book = FactoryBot.create(:book)
   end
 
-  should "return the book reference as the url parameter" do
+  it "returns the book reference as the url parameter" do
     copy = FactoryBot.create(:copy, book_reference: "123")
     assert_equal "123", copy.to_param
   end
 
-  context "creating a new copy" do
-    should "increment the book reference" do
+  describe "creating a new copy" do
+    it "increments the book reference" do
       first_copy = @book.copies.first # already created on book creation
       second_copy = @book.copies.create!(book_reference: 2)
       third_copy = @book.copies.create!
@@ -21,7 +21,7 @@ describe Copy do
       assert_equal 3, third_copy.book_reference
     end
 
-    should "not allow duplicate book references" do
+    it "does not allow duplicate book references" do
       first_copy = @book.copies.create!(book_reference: 30)
       second_copy = @book.copies.build(book_reference: 30)
 
@@ -29,25 +29,25 @@ describe Copy do
       assert_not second_copy.valid?
     end
 
-    should "set on_loan to false by default" do
+    it "sets on_loan to false by default" do
       copy = @book.copies.create!
 
       assert_equal false, copy.on_loan
     end
 
-    should "have no loans by default" do
+    it "has no loans by default" do
       copy = @book.copies.create!
 
       assert_equal 0, copy.loans.count
     end
   end
 
-  context "borrowing a book" do
+  describe "borrowing a book" do
     setup do
       @user = FactoryBot.create(:user)
     end
 
-    should "not allow a book already on loan to be borrowed" do
+    it "does not allow a book already on loan to be borrowed" do
       copy = FactoryBot.create(:copy_on_loan)
 
       assert_raises Copy::NotAvailable do
@@ -55,14 +55,14 @@ describe Copy do
       end
     end
 
-    should "create a new loan" do
+    it "creates a new loan" do
       copy = FactoryBot.create(:copy)
       copy.borrow(@user)
 
       assert_equal 1, copy.loans.count
     end
 
-    should "find the current loan" do
+    it "finds the current loan" do
       copy = FactoryBot.create(:copy)
       copy.borrow(@user)
 
@@ -70,7 +70,7 @@ describe Copy do
       assert_equal copy.current_loan.user_id, @user.id
     end
 
-    should "find the current user" do
+    it "finds the current user" do
       copy = FactoryBot.create(:copy)
       copy.borrow(@user)
 
@@ -78,13 +78,13 @@ describe Copy do
     end
   end
 
-  context "returning a copy" do
+  describe "returning a copy" do
     setup do
       @copy_on_loan = FactoryBot.create(:copy_on_loan)
       @user = @copy_on_loan.current_user
     end
 
-    should "return the loans attached to the copy" do
+    it "returns the loans attached to the copy" do
       loan = @copy_on_loan.loans.where(state: "on_loan").first
 
       @copy_on_loan.return
@@ -96,7 +96,7 @@ describe Copy do
       assert_equal false, @copy_on_loan.on_loan
     end
 
-    should "not allow a copy not on loan to be returned" do
+    it "does not allow a copy not on loan to be returned" do
       copy = FactoryBot.create(:copy)
 
       assert_raises Copy::NotOnLoan do
@@ -104,21 +104,21 @@ describe Copy do
       end
     end
 
-    should "only try to return current loans" do
+    it "only tries to return current loans" do
       previous_loan = @copy_on_loan.loans.create!(user: @user, state: "returned")
       previous_loan.expects(:return).never
 
       assert @copy_on_loan.return
     end
 
-    should "pass through the returning user when present" do
+    it "passes through the returning user when present" do
       user = create(:user)
       Loan.any_instance.expects(:return).with(user, nil)
 
       assert @copy_on_loan.return(user)
     end
 
-    should "return the copy to the specified shelf" do
+    it "returns the copy to the specified shelf" do
       user = create(:user)
       shelf = Shelf.first
 
@@ -129,8 +129,8 @@ describe Copy do
     end
   end
 
-  context "shelves" do
-    should "be able to set the shelf" do
+  describe "shelves" do
+    it "is able to set the shelf" do
       copy = FactoryBot.create(:copy)
       copy.update!(shelf_id: 1)
 
@@ -140,8 +140,8 @@ describe Copy do
     end
   end
 
-  context "recently added copies" do
-    should "return newest copies first" do
+  describe "recently added copies" do
+    it "returns newest copies first" do
       # delete first auto-generated copy of book
       @book.copies.delete_all
 

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -6,28 +6,28 @@ describe Loan do
     @user = FactoryBot.create(:user)
   end
 
-  context "creating a new loan" do
-    should "require a user" do
+  describe "creating a new loan" do
+    it "requires a user" do
       loan = @copy.loans.build(user: nil)
 
       assert_not loan.valid?
       assert ["can't be blank"], loan.errors[:user]
     end
 
-    should "require a copy" do
+    it "requires a copy" do
       loan = FactoryBot.build(:loan, copy: nil, user: @user)
 
       assert_not loan.valid?
       assert ["can't be blank"], loan.errors[:copy]
     end
 
-    should "set the state to 'on_loan' by default" do
+    it "sets the state to 'on_loan' by default" do
       loan = @copy.loans.create!(user: @user)
 
       assert_equal "on_loan", loan.state
     end
 
-    should "set the loan date by default" do
+    it "sets the loan date by default" do
       travel_to Time.zone.local(2021, 2, 1, 15, 44) do
         @loan = @copy.loans.create!(user: @user)
       end
@@ -35,7 +35,7 @@ describe Loan do
       assert_equal Time.zone.local(2021, 2, 1, 15, 44), @loan.loan_date
     end
 
-    should "set the copy on_loan attribute to true" do
+    it "sets the copy on_loan attribute to true" do
       @copy.loans.create!(user: @user)
       @copy.reload
 
@@ -43,25 +43,25 @@ describe Loan do
     end
   end
 
-  context "returning a loan" do
+  describe "returning a loan" do
     setup do
       @loan = @copy.loans.create!(user: @user)
     end
 
-    should "update the state to returned" do
+    it "updates the state to returned" do
       @loan.return
 
       assert_equal "returned", @loan.state
     end
 
-    should "set the copy on_loan attribute to false" do
+    it "sets the copy on_loan attribute to false" do
       @loan.return
       @copy.reload
 
       assert_not @copy.on_loan?
     end
 
-    should "raise an exception if already returned" do
+    it "raises an exception if already returned" do
       @loan.return
 
       assert_raises Loan::NotOnLoan do
@@ -69,7 +69,7 @@ describe Loan do
       end
     end
 
-    should "set the return date for the loan" do
+    it "sets the return date for the loan" do
       travel_to Time.zone.local(2021, 3, 3, 12, 59) do
         @loan.return
       end
@@ -77,7 +77,7 @@ describe Loan do
       assert_equal Time.zone.local(2021, 3, 3, 12, 59), @loan.return_date
     end
 
-    should "set the returning user when present" do
+    it "sets the returning user when present" do
       returning_user = create(:user)
       @loan.return(returning_user)
 
@@ -85,7 +85,7 @@ describe Loan do
       assert_equal returning_user, @loan.returned_by
     end
 
-    should "returned_by_another_user? is true if returned by a different user" do
+    it "returned_by_another_user? is true if returned by a different user" do
       returning_user = create(:user)
       @loan.return(returning_user)
       @loan.reload
@@ -93,7 +93,7 @@ describe Loan do
       assert @loan.returned_by_another_user?
     end
 
-    should "returned_by_another_user? is false if returned by the same user" do
+    it "returned_by_another_user? is false if returned by the same user" do
       returning_user = @loan.user
       @loan.return(returning_user)
       @loan.reload
@@ -101,7 +101,7 @@ describe Loan do
       assert_not @loan.returned_by_another_user?
     end
 
-    should "set the returning shelf when present" do
+    it "sets the returning shelf when present" do
       shelf = Shelf.first
       @loan.return(nil, shelf)
 
@@ -109,7 +109,7 @@ describe Loan do
       assert_equal shelf, @loan.returned_to_shelf
     end
 
-    should "measure the loan duration" do
+    it "measures the loan duration" do
       @loan.loan_date = Time.zone.local(2021, 1, 1)
       @loan.return_date = Time.zone.local(2021, 2, 1, 12, 0)
 


### PR DESCRIPTION
The `minitest-spec-rails` gem has the option to allow the [Shoulda](https://github.com/thoughtbot/shoulda) methods to be used in tests (`context`, `should` and `should_eventually`). According to the docs, this is designed to help when migrating away from Shoulda.

The tests are in a mix of styles, so this change aims to simplify them a little by just using `describe` and `it` everywhere consistently instead of having a mix of `describe` / `context` and `should` / `it`.