### PR TITLE
Rewrite the controller tests in a functional style

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,5 @@ group :test do
   gem "factory_bot_rails"
   gem "minitest-spec-rails"
   gem "mocha", require: false
-  gem "rails-controller-testing"
   gem "webmock", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,10 +231,6 @@ GEM
       activesupport (= 7.0.3)
       bundler (>= 1.15.0)
       railties (= 7.0.3)
-    rails-controller-testing (1.0.5)
-      actionpack (>= 5.0.1.rc1)
-      actionview (>= 5.0.1.rc1)
-      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -350,7 +346,6 @@ DEPENDENCIES
   pry-byebug
   puma
   rails (= 7.0.3)
-  rails-controller-testing
   rubocop-govuk
   sass-rails
   spring

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -2,7 +2,6 @@ require "csv"
 
 class RootController < ApplicationController
   def start
-    @books = Book.limit(8)
     @recently_added_copies = Copy.recently_added.limit(3)
     @recent_loans = Loan.recently_loaned.includes(%i[book copy]).limit(5)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   match "auth/:provider/callback", to: "sessions#create", via: %i[get post]
   get "auth/sign_out", to: "sessions#sign_out", as: :sign_out
 
-  get "library.csv", to: "root#library_csv"
+  get "library.csv", to: "root#library_csv", as: :library_csv
 
   resources :sessions, only: :new
 

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -2,8 +2,7 @@ require "integration_test_helper"
 
 class BooksControllerTest < ActionDispatch::IntegrationTest
   before do
-    post "/auth/google"
-    follow_redirect!
+    sign_in_user
   end
 
   describe "listing the books on the index page" do

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -1,40 +1,17 @@
-require "test_helper"
+require "integration_test_helper"
 
-describe RootController do
-  setup do
-    stub_user_session
+class RootControllerTest < ActionDispatch::IntegrationTest
+  before do
+    post "/auth/google"
+    follow_redirect!
   end
 
   describe "the start page" do
-    setup do
-      # create some books
-      FactoryBot.create_list(:book, 8)
-    end
-
     it "returns a successful response" do
-      get :start
+      get root_path
 
-      assert response.successful?
-    end
-
-    it "loads eight books to display to the user" do
-      get :start
-
-      assert_equal 8, assigns(:books).count
-      assert_instance_of Book, assigns(:books).first
-    end
-
-    it "loads 3 recently added copies to display to the user" do
-      get :start
-
-      assert_equal 3, assigns(:recently_added_copies).count
-      assert_instance_of Copy, assigns(:recently_added_copies).first
-    end
-
-    it "renders the start template" do
-      get :start
-
-      assert_template "start"
+      assert_match(/Welcome, Stub User!/, @response.body)
+      assert_response :success
     end
   end
 
@@ -43,7 +20,7 @@ describe RootController do
       FactoryBot.create(:book, id: 1, title: "Book 1", author: "A. One", isbn: "1")
       FactoryBot.create(:book, id: 2, title: "Book 2", author: "A. Two", isbn: "2")
 
-      get :library_csv
+      get library_csv_path
 
       assert_response :success
       assert_equal "text/csv", @response.media_type

--- a/test/controllers/root_controller_test.rb
+++ b/test/controllers/root_controller_test.rb
@@ -2,8 +2,7 @@ require "integration_test_helper"
 
 class RootControllerTest < ActionDispatch::IntegrationTest
   before do
-    post "/auth/google"
-    follow_redirect!
+    sign_in_user
   end
 
   describe "the start page" do

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -10,8 +10,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     it "redirects with an error if the auth hash is empty" do
       OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new({})
 
-      post "/auth/google"
-      follow_redirect!
+      sign_in_user
 
       assert_redirected_to new_session_path
       assert_equal "There was a problem signing you in.", @controller.flash[:alert]
@@ -28,8 +27,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       }
       OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(auth_hash)
 
-      post "/auth/google"
-      follow_redirect!
+      sign_in_user
 
       assert_equal user.id, @controller.session[:user_id]
       assert_redirected_to root_path
@@ -42,8 +40,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
         .with(auth_hash)
         .returns(nil)
 
-      post "/auth/google"
-      follow_redirect!
+      sign_in_user
 
       assert_nil @controller.session[:user_id]
       assert_redirected_to new_session_path
@@ -56,8 +53,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
         .with(auth_hash)
         .raises(User::CreationFailure.new("something bad"))
 
-      post "/auth/google"
-      follow_redirect!
+      sign_in_user
 
       assert_redirected_to new_session_path
       assert_match(/Could not sign you in/, @controller.flash[:alert])
@@ -77,8 +73,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
       }
       OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(auth_hash)
 
-      post "/auth/google"
-      follow_redirect!
+      sign_in_user
 
       assert_equal user.id, @controller.session[:user_id]
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,14 +1,12 @@
 require "integration_test_helper"
 
 class SessionsControllerTest < ActionDispatch::IntegrationTest
-  let(:auth_hash) do
-    { "uid" => "12345" }
-  end
   let(:user) { create(:user) }
 
   describe "POST create" do
     it "redirects with an error if the auth hash is empty" do
-      OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new({})
+      auth_hash = {}
+      mock_hash_returned_by_omniauth(auth_hash)
 
       sign_in_user
 
@@ -25,7 +23,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
           email: user.email,
         },
       }
-      OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(auth_hash)
+      mock_hash_returned_by_omniauth(auth_hash)
 
       sign_in_user
 
@@ -34,7 +32,8 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     end
 
     it "redirects with an error if the user cannot be found" do
-      OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(auth_hash)
+      auth_hash = { "uid" => "12345" }
+      mock_hash_returned_by_omniauth(auth_hash)
 
       User.expects(:find_or_create_from_auth_hash!)
         .with(auth_hash)
@@ -47,7 +46,8 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     end
 
     it "redirects with error when creating a user fails" do
-      OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(auth_hash)
+      auth_hash = { "uid" => "12345" }
+      mock_hash_returned_by_omniauth(auth_hash)
 
       User.expects(:find_or_create_from_auth_hash!)
         .with(auth_hash)
@@ -71,7 +71,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
           email: user.email,
         },
       }
-      OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(auth_hash)
+      mock_hash_returned_by_omniauth(auth_hash)
 
       sign_in_user
 

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,52 +1,63 @@
-require "test_helper"
+require "integration_test_helper"
 
-describe SessionsController do
+class SessionsControllerTest < ActionDispatch::IntegrationTest
   let(:auth_hash) do
     { "uid" => "12345" }
   end
   let(:user) { create(:user) }
 
-  setup do
-    stub_omniauth_request_auth_hash(auth_hash)
-  end
-
   describe "POST create" do
-    it "redirects with an error when the auth hash is empty" do
-      stub_omniauth_request_auth_hash({})
-      post :create, params: { provider: :google }
+    it "redirects with an error if the auth hash is empty" do
+      OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new({})
+
+      post "/auth/google"
+      follow_redirect!
 
       assert_redirected_to new_session_path
       assert_equal "There was a problem signing you in.", @controller.flash[:alert]
     end
 
     it "signs in a user with the provided auth hash" do
-      User.expects(:find_or_create_from_auth_hash!)
-          .with(auth_hash)
-          .returns(user)
+      auth_hash = {
+        provider: "google",
+        uid: "12345",
+        info: {
+          name: user.name,
+          email: user.email,
+        },
+      }
+      OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(auth_hash)
 
-      post :create, params: { provider: :google }
+      post "/auth/google"
+      follow_redirect!
 
       assert_equal user.id, @controller.session[:user_id]
       assert_redirected_to root_path
     end
 
     it "redirects with an error if the user cannot be found" do
-      User.expects(:find_or_create_from_auth_hash!)
-          .with(auth_hash)
-          .returns(nil)
+      OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(auth_hash)
 
-      post :create, params: { provider: :google }
+      User.expects(:find_or_create_from_auth_hash!)
+        .with(auth_hash)
+        .returns(nil)
+
+      post "/auth/google"
+      follow_redirect!
 
       assert_nil @controller.session[:user_id]
       assert_redirected_to new_session_path
     end
 
     it "redirects with error when creating a user fails" do
-      User.expects(:find_or_create_from_auth_hash!)
-          .with(auth_hash)
-          .raises(User::CreationFailure.new("something bad"))
+      OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(auth_hash)
 
-      post :create, params: { provider: :google }
+      User.expects(:find_or_create_from_auth_hash!)
+        .with(auth_hash)
+        .raises(User::CreationFailure.new("something bad"))
+
+      post "/auth/google"
+      follow_redirect!
 
       assert_redirected_to new_session_path
       assert_match(/Could not sign you in/, @controller.flash[:alert])
@@ -56,14 +67,22 @@ describe SessionsController do
 
   describe "GET sign_out" do
     it "clears the session and redirects" do
-      User.expects(:find_or_create_from_auth_hash!)
-          .with(auth_hash)
-          .returns(user)
+      auth_hash = {
+        provider: "google",
+        uid: "12345",
+        info: {
+          name: user.name,
+          email: user.email,
+        },
+      }
+      OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(auth_hash)
 
-      post :create, params: { provider: :google }
+      post "/auth/google"
+      follow_redirect!
+
       assert_equal user.id, @controller.session[:user_id]
 
-      get :sign_out
+      get sign_out_path
       assert_nil @controller.session[:user_id]
       assert_redirected_to new_session_path
     end

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -2,8 +2,7 @@ require "integration_test_helper"
 
 class UserControllerTest < ActionDispatch::IntegrationTest
   before do
-    post "/auth/google"
-    follow_redirect!
+    sign_in_user
   end
 
   it "gets the user page" do

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -1,13 +1,17 @@
-require "test_helper"
+require "integration_test_helper"
 
-describe UserController do
+class UserControllerTest < ActionDispatch::IntegrationTest
+  before do
+    post "/auth/google"
+    follow_redirect!
+  end
+
   it "gets the user page" do
-    stub_user_session
-    user = User.all.first
+    my_user = User.find_by(email: "stub.user@example.org")
 
-    get :show, params: { id: user.id }
+    get user_url(my_user.id)
 
     assert_response :success
-    assert_template "show"
+    assert_match(/Stub User’s Books/, @response.body)
   end
 end

--- a/test/integration/book_actions_test.rb
+++ b/test/integration/book_actions_test.rb
@@ -3,7 +3,7 @@ require "integration_test_helper"
 class BookActionsTest < ActionDispatch::IntegrationTest
   describe "a signed in user" do
     setup do
-      sign_in_user
+      sign_in_user_with_capybara
     end
 
     describe "given a book exists" do

--- a/test/integration/copy_actions_test.rb
+++ b/test/integration/copy_actions_test.rb
@@ -3,7 +3,7 @@ require "integration_test_helper"
 class CopyActionsTest < ActionDispatch::IntegrationTest
   describe "a signed in user" do
     setup do
-      sign_in_user
+      sign_in_user_with_capybara
     end
 
     describe "given an available copy exists" do

--- a/test/integration/start_page_test.rb
+++ b/test/integration/start_page_test.rb
@@ -3,7 +3,7 @@ require "integration_test_helper"
 class StartPageTest < ActionDispatch::IntegrationTest
   describe "as a signed in user" do
     setup do
-      sign_in_user
+      sign_in_user_with_capybara
     end
 
     it "loads the start page" do

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -1,17 +1,15 @@
 require_relative "test_helper"
 require "capybara/rails"
 
-include OmniAuthStubHelper # rubocop:disable Style/MixinUsage
-prepare_omniauth_for_testing
-
 class ActionDispatch::IntegrationTest
   include Capybara::DSL
+  include OmniAuthStubHelper
 
-  teardown do
-    Capybara.use_default_driver
-
-    # The omniauth auth hash gets overwritten in some tests, so we reset it to "the standard one"
-    # at the end of each test
+  before do
     prepare_omniauth_for_testing
+  end
+
+  after do
+    Capybara.use_default_driver
   end
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -9,5 +9,9 @@ class ActionDispatch::IntegrationTest
 
   teardown do
     Capybara.use_default_driver
+
+    # The omniauth auth hash gets overwritten in some tests, so we reset it to "the standard one"
+    # at the end of each test
+    prepare_omniauth_for_testing
   end
 end

--- a/test/support/omniauth_stub_helper.rb
+++ b/test/support/omniauth_stub_helper.rb
@@ -2,7 +2,11 @@ module OmniAuthStubHelper
   # suitable for integration tests
   def prepare_omniauth_for_testing
     OmniAuth.config.test_mode = true
-    OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(mock_auth_hash)
+    mock_hash_returned_by_omniauth
+  end
+
+  def mock_hash_returned_by_omniauth(hash_returned = mock_auth_hash)
+    OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(hash_returned)
   end
 
   def sign_in_user_with_capybara

--- a/test/support/omniauth_stub_helper.rb
+++ b/test/support/omniauth_stub_helper.rb
@@ -5,9 +5,14 @@ module OmniAuthStubHelper
     OmniAuth.config.mock_auth[:google] = OmniAuth::AuthHash.new(mock_auth_hash)
   end
 
-  def sign_in_user
+  def sign_in_user_with_capybara
     visit new_session_path
     click_on "Sign in with Google"
+  end
+
+  def sign_in_user
+    post "/auth/google"
+    follow_redirect!
   end
 
   def signed_in_user

--- a/test/support/omniauth_stub_helper.rb
+++ b/test/support/omniauth_stub_helper.rb
@@ -14,11 +14,6 @@ module OmniAuthStubHelper
     User.find_by(email: mock_auth_hash[:info][:email])
   end
 
-  # suitable for controller tests
-  def stub_omniauth_request_auth_hash(auth_hash = mock_auth_hash)
-    request.env["omniauth.auth"] = auth_hash
-  end
-
   def mock_auth_hash
     {
       provider: "google",

--- a/test/support/user_session_stub_helper.rb
+++ b/test/support/user_session_stub_helper.rb
@@ -1,9 +1,0 @@
-module UserSessionStubHelper
-  def stub_user_session
-    @controller.session[:user_id] = stub_user.id
-  end
-
-  def stub_user
-    @stub_user ||= create(:user)
-  end
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,8 +26,3 @@ class ActiveSupport::TestCase
     DatabaseCleaner.clean
   end
 end
-
-class ActionController::TestCase
-  include OmniAuthStubHelper
-  include UserSessionStubHelper
-end


### PR DESCRIPTION
The controller tests were making heavy use of `assigns` and `assert_template` - methods which have been [deprecated from Rails](https://github.com/rails/rails/issues/18950) and which we needed to bring in the `rails-controller-testing` gem for. This updates the controller tests to be functional tests, which is the advised way of testing controllers. Note, this doesn't attempt to increase the test coverage yet - just to be a like-for-like replacement of the existing tests.