### PR TITLE
Stop specifying stack in manifest.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 log/
 tmp/
 .env
+/coverage

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,6 @@
 applications:
 - name: gds-library
   memory: 256M
-  stack: cflinuxfs3
   buildpacks:
     - ruby_buildpack
   instances: 2


### PR DESCRIPTION
`stack` was added when we were using a custom buildpack. We've been using the standard ruby_buildpack for a while now so no longer need it.

Also adds `/coverage` to the .gitignore so we don't accidentally commit the coverage files