### PR TITLE
Remove unused webmock gem and fix a few tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,5 +29,4 @@ group :test do
   gem "factory_bot_rails"
   gem "minitest-spec-rails"
   gem "mocha", require: false
-  gem "webmock", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,8 +82,6 @@ GEM
       xpath (~> 3.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
-    crack (0.4.5)
-      rexml
     crass (1.0.6)
     database_cleaner-active_record (2.0.1)
       activerecord (>= 5.a)
@@ -112,7 +110,6 @@ GEM
     has_scope (0.8.0)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
-    hashdiff (1.0.1)
     hashie (5.0.0)
     http-accept (1.7.0)
     http-cookie (1.0.5)
@@ -313,10 +310,6 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (2.2.0)
-    webmock (3.14.0)
-      addressable (>= 2.8.0)
-      crack (>= 0.3.2)
-      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -350,7 +343,6 @@ DEPENDENCIES
   rubocop-govuk
   sass-rails
   spring
-  webmock
 
 RUBY VERSION
    ruby 3.1.1p18

--- a/test/integration/start_page_test.rb
+++ b/test/integration/start_page_test.rb
@@ -32,7 +32,7 @@ class StartPageTest < ActionDispatch::IntegrationTest
         click_on "Go"
       end
 
-      assert "/copy/123", current_path
+      assert_equal "/copy/123", current_path
     end
 
     it "shows an error when a user attempts to look up an invalid copy id" do
@@ -43,7 +43,7 @@ class StartPageTest < ActionDispatch::IntegrationTest
         click_on "Go"
       end
 
-      assert "/", current_path
+      assert_equal "/", current_path
       assert page.has_content?("Copy 999 couldn't be found")
     end
 

--- a/test/models/copy_test.rb
+++ b/test/models/copy_test.rb
@@ -125,7 +125,7 @@ describe Copy do
       Loan.any_instance.expects(:return).with(user, shelf)
 
       @copy_on_loan.return(user, shelf)
-      assert shelf, @copy_on_loan.shelf
+      assert_equal shelf, @copy_on_loan.shelf
     end
   end
 

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -11,14 +11,14 @@ describe Loan do
       loan = @copy.loans.build(user: nil)
 
       assert_not loan.valid?
-      assert ["can't be blank"], loan.errors[:user]
+      assert_equal ["can't be blank"], loan.errors[:user]
     end
 
     it "requires a copy" do
       loan = FactoryBot.build(:loan, copy: nil, user: @user)
 
       assert_not loan.valid?
-      assert ["can't be blank"], loan.errors[:copy]
+      assert_equal ["can't be blank"], loan.errors[:copy]
     end
 
     it "sets the state to 'on_loan' by default" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,14 +2,11 @@ ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../config/environment", __dir__)
 require "rails/test_help"
 require "mocha/minitest"
-require "webmock"
 
 Dir[Rails.root.join("test/support/*.rb")].sort.each { |f| require f }
 
 DatabaseCleaner.strategy = :transaction
 DatabaseCleaner.clean
-
-WebMock.disable_net_connect!
 
 class ActiveSupport::TestCase
   ActiveRecord::Migration.check_pending!


### PR DESCRIPTION
This removes the unused webmock dependency and fixes some tests which were always passing due to the wrong assertions being used.