### PR TITLE
Stop storing shelf for loans

### DIFF
--- a/app/models/copy.rb
+++ b/app/models/copy.rb
@@ -58,7 +58,7 @@ class Copy < ApplicationRecord
     raise NotOnLoan unless on_loan?
 
     loans.where(state: "on_loan").find_each do |loan|
-      loan.return(as_user, to_shelf)
+      loan.return(as_user)
     end
 
     self.shelf = to_shelf

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -2,7 +2,6 @@ class Loan < ApplicationRecord
   belongs_to :copy
   belongs_to :user
   belongs_to :returned_by, class_name: "User"
-  belongs_to :returned_to_shelf, class_name: "Shelf"
 
   has_one :book, through: :copy
 
@@ -19,13 +18,12 @@ class Loan < ApplicationRecord
 
   class NotOnLoan < RuntimeError; end
 
-  def return(as_user = nil, to_shelf = nil)
+  def return(as_user = nil)
     raise NotOnLoan unless state == "on_loan"
 
     self.state = "returned"
     self.return_date = Time.zone.now
     self.returned_by = as_user
-    self.returned_to_shelf = to_shelf
     save!
   end
 

--- a/app/views/copies/show.html.erb
+++ b/app/views/copies/show.html.erb
@@ -22,7 +22,6 @@
         <th>From</th>
         <th>Until</th>
         <th>Duration</th>
-        <th>Returned to</th>
         <th>by</th>
       </thead>
 
@@ -31,7 +30,6 @@
         <td><%= loan.loan_date.strftime("%e %B %Y") if loan.loan_date %></td>
         <td><%= loan.return_date.strftime("%e %B %Y") if loan.return_date %></td>
         <td><%= distance_of_time_in_words(loan.duration) if loan.duration %></td>
-        <td><%= loan.returned_to_shelf if loan.returned_to_shelf %></td>
         <td>
           <%= link_to loan.user.name, user_path(loan.user) %>
           <% if loan.returned_by_another_user? %>

--- a/db/migrate/20220817084740_remove_returned_to_shelf_id_from_loans.rb
+++ b/db/migrate/20220817084740_remove_returned_to_shelf_id_from_loans.rb
@@ -1,0 +1,5 @@
+class RemoveReturnedToShelfIdFromLoans < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :loans, :returned_to_shelf_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_04_15_151215) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_17_084740) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -74,7 +74,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_04_15_151215) do
     t.datetime "updated_at", precision: nil, null: false
     t.datetime "return_date", precision: nil
     t.integer "returned_by_id"
-    t.integer "returned_to_shelf_id"
   end
 
   create_table "shelves", id: :serial, force: :cascade do |t|

--- a/test/integration/copy_actions_test.rb
+++ b/test/integration/copy_actions_test.rb
@@ -142,10 +142,10 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
 
         rows = page.all("table.history tr").map { |r| r.all("th, td").map(&:text).map(&:strip) }
         assert_equal [
-          ["From", "Until", "Duration", "Returned to", "by"],
-          ["17 June 2012", "10 July 2012", "23 days", "", "Julia"],
-          ["5 April 2012", "1 May 2012", "26 days", "", "Emmanuel Goldstein"],
-          ["1 January 2012", "15 January 2012", "14 days", "", "Julia"],
+          ["From", "Until", "Duration", "by"],
+          ["17 June 2012", "10 July 2012", "23 days", "Julia"],
+          ["5 April 2012", "1 May 2012", "26 days", "Emmanuel Goldstein"],
+          ["1 January 2012", "15 January 2012", "14 days", "Julia"],
         ], rows
       end
 

--- a/test/models/copy_test.rb
+++ b/test/models/copy_test.rb
@@ -122,7 +122,7 @@ describe Copy do
       user = create(:user)
       shelf = Shelf.first
 
-      Loan.any_instance.expects(:return).with(user, shelf)
+      Loan.any_instance.expects(:return).with(user)
 
       @copy_on_loan.return(user, shelf)
       assert_equal shelf, @copy_on_loan.shelf

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -101,14 +101,6 @@ describe Loan do
       assert_not @loan.returned_by_another_user?
     end
 
-    it "sets the returning shelf when present" do
-      shelf = Shelf.first
-      @loan.return(nil, shelf)
-
-      @loan.reload
-      assert_equal shelf, @loan.returned_to_shelf
-    end
-
     it "measures the loan duration" do
       @loan.loan_date = Time.zone.local(2021, 1, 1)
       @loan.return_date = Time.zone.local(2021, 2, 1, 12, 0)


### PR DESCRIPTION
We don't have two shelves any more, so will need to change how we deal
with shelves / locations of copies. As a first step, this removes the
concept of shelves from loans. A loan now no longer belongs to a shelf,
which means that we don't have to keep a record of shelves which no
longer exist - we only care about current shelves and where a copy is now.

This removes shelves from the loan model and table.