### PR TITLE
Rename "shelves" to "locations"

### DIFF
--- a/app/assets/stylesheets/books.scss
+++ b/app/assets/stylesheets/books.scss
@@ -114,7 +114,7 @@ ul.copies {
 
     p, h2 { display: inline; margin: 0; padding: 0; font-size: 1em; }
 
-    .shelf {
+    .location {
       font-weight: normal;
       font-size: 80%;
     }
@@ -177,7 +177,7 @@ ul.copies {
       overflow: initial;
     }
 
-    #copy_shelf_input {
+    #copy_location_input {
       label {
         width: 6em;
         text-align: right;

--- a/app/assets/stylesheets/copies.scss
+++ b/app/assets/stylesheets/copies.scss
@@ -81,7 +81,7 @@ fieldset.copy-number {
   }
 }
 
-fieldset.shelf {
+fieldset.location {
   display: block;
   margin: 1.5em 0 0 0;
   padding: 1em;

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -7,7 +7,7 @@ class BooksController < ApplicationController
   has_scope :availability do |_controller, scope, value|
     case value
     when "available" then scope.available
-    when /^shelf_[0-9]+$/ then scope.shelf(value.split("_")[1])
+    when /^location_[0-9]+$/ then scope.location(value.split("_")[1])
     when "on_loan" then scope.on_loan
     when "missing" then scope.missing
     else

--- a/app/controllers/copies_controller.rb
+++ b/app/controllers/copies_controller.rb
@@ -43,7 +43,7 @@ class CopiesController < ApplicationController
   def update
     @copy = Copy.find_by(book_reference: params[:id])
     if @copy.update(params.require(:copy).permit(:location_id))
-      flash[:notice] = "Shelf updated"
+      flash[:notice] = "Location updated"
       redirect_to copy_path(@copy)
     else
       render action: :edit

--- a/app/controllers/copies_controller.rb
+++ b/app/controllers/copies_controller.rb
@@ -42,7 +42,7 @@ class CopiesController < ApplicationController
 
   def update
     @copy = Copy.find_by(book_reference: params[:id])
-    if @copy.update(params.require(:copy).permit(:shelf_id))
+    if @copy.update(params.require(:copy).permit(:location_id))
       flash[:notice] = "Shelf updated"
       redirect_to copy_path(@copy)
     else
@@ -61,10 +61,10 @@ class CopiesController < ApplicationController
   end
 
   def return
-    if resource.return(current_user, shelf)
+    if resource.return(current_user, location)
       msg = "Copy #{resource.book_reference} has now been returned"
-      if shelf
-        msg << " to #{shelf}"
+      if location
+        msg << " to #{location}"
       end
       msg << ". Thanks!"
       flash[:notice] = msg
@@ -89,9 +89,9 @@ class CopiesController < ApplicationController
 
 private
 
-  def shelf
-    shelf_id = params.require(:copy).fetch(:shelf_id, nil)
-    shelf_id && Shelf.find_by(id: shelf_id)
+  def location
+    location_id = params.require(:copy)[:location_id]
+    location_id && Location.find_by(id: location_id)
   end
 
   def parent
@@ -103,6 +103,6 @@ private
   end
 
   def copy_params
-    params.require(:copy).permit(:book_id, :book_reference, :on_loan, :shelf_id)
+    params.require(:copy).permit(:book_id, :book_reference, :on_loan, :location_id)
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -18,7 +18,7 @@ class Book < ApplicationRecord
   scope :available, -> { joins(:copies).where(copies: { on_loan: false }) }
   scope :on_loan, -> { joins(:copies).where(copies: { on_loan: true }) }
   scope :missing, -> { joins(:copies).where(copies: { missing: true }) }
-  scope :shelf, ->(shelf_id) { joins(:copies).where(copies: { on_loan: false, shelf_id: }) }
+  scope :location, ->(location_id) { joins(:copies).where(copies: { on_loan: false, location_id: }) }
 
   default_scope -> { order("title ASC") }
 

--- a/app/models/copy.rb
+++ b/app/models/copy.rb
@@ -2,7 +2,7 @@ class Copy < ApplicationRecord
   belongs_to :book
   has_many :loans, dependent: :destroy
   has_many :users, through: :loans
-  belongs_to :shelf
+  belongs_to :location
 
   validates :book_reference, presence: true, uniqueness: true
 
@@ -54,14 +54,14 @@ class Copy < ApplicationRecord
     loans.create!(user:)
   end
 
-  def return(as_user = nil, to_shelf = nil)
+  def return(as_user = nil, to_location = nil)
     raise NotOnLoan unless on_loan?
 
     loans.where(state: "on_loan").find_each do |loan|
       loan.return(as_user)
     end
 
-    self.shelf = to_shelf
+    self.location = to_location
     save!
   end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,4 +1,4 @@
-class Shelf < ApplicationRecord
+class Location < ApplicationRecord
   has_many :books
 
   def to_s

--- a/app/views/books/_filters.html.erb
+++ b/app/views/books/_filters.html.erb
@@ -3,8 +3,8 @@
     <h3>availability</h3>
     <ul>
       <li><%= filter_link "available", :availability, "available" %></li>
-      <% Shelf.all.each do |shelf| %>
-        <li><%= filter_link "- #{shelf}", :availability, "shelf_#{shelf.id}" %></li>
+      <% Location.all.each do |location| %>
+        <li><%= filter_link "- #{location}", :availability, "location_#{location.id}" %></li>
       <% end %>
       <li><%= filter_link "on loan", :availability, "on_loan" %></li>
       <li><%= filter_link "missing", :availability, "missing" %></li>

--- a/app/views/copies/_copy.html.erb
+++ b/app/views/copies/_copy.html.erb
@@ -10,7 +10,7 @@
 
       <%= semantic_form_for [:return, copy], method: :post do |f| %>
         <ul>
-          <%= f.input :shelf,  :as => :select,      :collection => Shelf.all, include_blank: "unknown", label: "Return to" %>
+          <%= f.input :location, as: :select, collection: Location.all, include_blank: "unknown", label: "Return to" %>
 
           <li><%= f.submit "Return" %></li>
         </ul>
@@ -26,9 +26,9 @@
   <% elsif copy.available? %>
     <p>
       Available to borrow
-      <span class='shelf'>
-      <% if copy.shelf.present? %>
-        (<%= copy.shelf.to_s %> - <%= link_to "edit", edit_copy_path(copy) %>)
+      <span class="location">
+      <% if copy.location.present? %>
+        (<%= copy.location.to_s %> - <%= link_to "edit", edit_copy_path(copy) %>)
       <% else %>
         (shelf unknown - <%= link_to "set", edit_copy_path(copy) %>)
       <% end %>

--- a/app/views/copies/_copy.html.erb
+++ b/app/views/copies/_copy.html.erb
@@ -30,7 +30,7 @@
       <% if copy.location.present? %>
         (<%= copy.location.to_s %> - <%= link_to "edit", edit_copy_path(copy) %>)
       <% else %>
-        (shelf unknown - <%= link_to "set", edit_copy_path(copy) %>)
+        (location unknown - <%= link_to "set", edit_copy_path(copy) %>)
       <% end %>
       </span>
       <%= link_to "Borrow", borrow_copy_path(copy), :class => 'btn', :method => :post %>

--- a/app/views/copies/edit.html.erb
+++ b/app/views/copies/edit.html.erb
@@ -11,7 +11,7 @@
   </div>
 
   <%= semantic_form_for [@copy] do |f| %>
-    <h3>Which shelf is this book on?</h3>
+    <h3>Where is this copy?</h3>
 
     <fieldset class="location">
       <label>
@@ -20,7 +20,7 @@
     </fieldset>
 
     <%= f.actions do %>
-      <%= f.submit "Set shelf" %>
+      <%= f.submit "Set location" %>
     <% end %>
   <% end %>
 </section>

--- a/app/views/copies/edit.html.erb
+++ b/app/views/copies/edit.html.erb
@@ -13,9 +13,9 @@
   <%= semantic_form_for [@copy] do |f| %>
     <h3>Which shelf is this book on?</h3>
 
-    <fieldset class="shelf">
+    <fieldset class="location">
       <label>
-        <%= f.input :shelf,  :as => :select,      :collection => Shelf.all, include_blank: "unknown" %>
+        <%= f.input :location, as: :select, collection: Location.all, include_blank: "unknown" %>
       </label>
     </fieldset>
 

--- a/app/views/copies/new.html.erb
+++ b/app/views/copies/new.html.erb
@@ -22,9 +22,9 @@
       </label>
     </fieldset>
 
-    <fieldset class="shelf">
-      <label for="shelf">
-        <%= f.input :shelf,  :as => :select,      :collection => Shelf.all, include_blank: "unknown" %>
+    <fieldset class="location">
+      <label for="location">
+        <%= f.input :location, as: :select, collection: Location.all, include_blank: "unknown" %>
       </label>
     </fieldset>
 

--- a/db/migrate/20170408104943_add_shelves.rb
+++ b/db/migrate/20170408104943_add_shelves.rb
@@ -7,8 +7,5 @@ class AddShelves < ActiveRecord::Migration[5.2]
 
     add_column :copies, :shelf_id, :integer, default: nil
     add_column :loans, :returned_to_shelf_id, :integer, default: nil
-
-    execute "insert into shelves (name, created_at, updated_at) select 'Third floor', now(), now()"
-    execute "insert into shelves (name, created_at, updated_at) select 'Sixth floor', now(), now()"
   end
 end

--- a/db/migrate/20220817124354_rename_shelves_to_locations.rb
+++ b/db/migrate/20220817124354_rename_shelves_to_locations.rb
@@ -1,0 +1,6 @@
+class RenameShelvesToLocations < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :shelves, :locations
+    rename_column :copies, :shelf_id, :location_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_17_084740) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_17_124354) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -62,7 +62,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_17_084740) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "missing", default: false
-    t.integer "shelf_id"
+    t.integer "location_id"
   end
 
   create_table "loans", id: :serial, force: :cascade do |t|
@@ -76,7 +76,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_17_084740) do
     t.integer "returned_by_id"
   end
 
-  create_table "shelves", id: :serial, force: :cascade do |t|
+  create_table "locations", id: :serial, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,2 @@
-Shelf.create!(name: "6th floor")
-Shelf.create!(name: "7th floor")
+Location.create!(name: "6th floor")
+Location.create!(name: "7th floor")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,2 @@
-Location.create!(name: "6th floor")
-Location.create!(name: "7th floor")
+Location.create!(name: "GDS London hub")
+Location.create!(name: "GDS Bristol hub")

--- a/test/integration/copy_actions_test.rb
+++ b/test/integration/copy_actions_test.rb
@@ -41,20 +41,20 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
         assert page.has_link?("See all copies of this book", href: "/books/#{@copy.book.id}")
       end
 
-      describe "given a shelf exists" do
-        it "allows the shelf to be set" do
+      describe "given a location exists" do
+        it "allows the location to be set" do
           visit "/copy/123"
-          within ".shelf" do
+          within ".location" do
             click_link "set"
           end
 
           assert_equal "/copy/123/edit", current_path
 
-          select "6th floor", from: "Shelf"
+          select "6th floor", from: "Location"
           click_on "Set shelf"
 
           assert_equal "/copy/123", current_path
-          within ".shelf" do
+          within ".location" do
             assert page.has_content?("6th floor")
           end
         end
@@ -84,7 +84,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
         assert_equal "/copy/123", current_path
         assert page.has_content?("123")
         assert page.has_content?("Available to borrow")
-        within ".shelf" do
+        within ".location" do
           assert page.has_content?("7th floor")
         end
       end

--- a/test/integration/copy_actions_test.rb
+++ b/test/integration/copy_actions_test.rb
@@ -50,12 +50,12 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
 
           assert_equal "/copy/123/edit", current_path
 
-          select "6th floor", from: "Location"
+          select "GDS London hub", from: "Location"
           click_on "Set location"
 
           assert_equal "/copy/123", current_path
           within ".location" do
-            assert page.has_content?("6th floor")
+            assert page.has_content?("GDS London hub")
           end
         end
       end
@@ -78,14 +78,14 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
 
       it "allows the book to be returned" do
         visit "/copy/123"
-        select "7th floor", from: "Return to"
+        select "GDS Bristol hub", from: "Return to"
         click_on "Return"
 
         assert_equal "/copy/123", current_path
         assert page.has_content?("123")
         assert page.has_content?("Available to borrow")
         within ".location" do
-          assert page.has_content?("7th floor")
+          assert page.has_content?("GDS Bristol hub")
         end
       end
     end

--- a/test/integration/copy_actions_test.rb
+++ b/test/integration/copy_actions_test.rb
@@ -51,7 +51,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
           assert_equal "/copy/123/edit", current_path
 
           select "6th floor", from: "Location"
-          click_on "Set shelf"
+          click_on "Set location"
 
           assert_equal "/copy/123", current_path
           within ".location" do

--- a/test/models/copy_test.rb
+++ b/test/models/copy_test.rb
@@ -118,25 +118,25 @@ describe Copy do
       assert @copy_on_loan.return(user)
     end
 
-    it "returns the copy to the specified shelf" do
+    it "returns the copy to the specified location" do
       user = create(:user)
-      shelf = Shelf.first
+      location = Location.first
 
       Loan.any_instance.expects(:return).with(user)
 
-      @copy_on_loan.return(user, shelf)
-      assert_equal shelf, @copy_on_loan.shelf
+      @copy_on_loan.return(user, location)
+      assert_equal location, @copy_on_loan.location
     end
   end
 
-  describe "shelves" do
-    it "is able to set the shelf" do
+  describe "the location of copies" do
+    it "is possible to update a copy's location" do
       copy = FactoryBot.create(:copy)
-      copy.update!(shelf_id: 1)
+      copy.update!(location_id: 1)
 
       copy.reload
 
-      assert_equal 1, copy.shelf_id
+      assert_equal 1, copy.location_id
     end
   end
 


### PR DESCRIPTION
This change:

**Renames "shelves" to "locations" in the backend code**
We want the app to show copies in different locations, but the different locations are going to be different office buildings, and not different shelves in the same building. To prepare for this change, this commit starts to rename "shelf" and "shelves" to "location" and "locations" in the backend code. This renames

- The `shelves` table to `locations`
- The `shelf_id` column of the `copies` table to `location_id`
- Method names, and HTML class and ID names

**Updates frontend code which references shelves**

**Adds new locations to code**
This removes the lines from the AddShelves migration which inserts rows into the shelves table (since renamed to the locations table). You will now need to manually enter locations in the database, but it also means that if you don't want your locations to be called 'Third floor' and 'Sixth floor' you can safely run all migrations.

The seed data for the tests has also been changed.