### PR TITLE
Fix bug with `formatted_version_author` helper method

### DIFF
--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -23,11 +23,10 @@ module BooksHelper
 
   def formatted_version_author(version)
     user_id = version.whodunnit
-    if user_id.blank?
-      "Unknown user"
-    else
-      User.where(id: user_id).first.name || "Unknown user"
-    end
+
+    # user_id can be an empty string or can belong to a user who no longer exists in
+    # the database due to bad data
+    User.where(id: user_id).first.try(:name) || "Unknown user"
   end
 
   def formatted_version_changes(version)


### PR DESCRIPTION
We try to look up a user by ID if the ID exists. This should be fine but it is sometimes giving errors because of the state of the data - we have some user IDs in the `versions` table for users who no longer exist in the `users` table.

This fixes the issue by no longer making the assumption that `User.where(id: user_id).first` will return a `User` when passed a `user_id`.