### PR TITLE
Accessibility fixes for the HTML

### DIFF
--- a/app/assets/stylesheets/books.scss
+++ b/app/assets/stylesheets/books.scss
@@ -82,7 +82,7 @@ section.single_book {
     td { padding: 0.5em 1em; border-color: #ccc; }
   }
 
-  nav.actions {
+  div.actions {
     font-size: 0.75em;
     margin: 1em;
 

--- a/app/assets/stylesheets/books.scss
+++ b/app/assets/stylesheets/books.scss
@@ -74,7 +74,9 @@ section.single_book {
     h2 { font-size: 1em; font-weight: normal; }
   }
 
-  p, h3 { padding: 0 1rem; }
+  p {
+    padding: 0 1rem;
+  }
 
   .action { border: 1px solid #aaa; text-align: right; padding: 0.5em; }
 

--- a/app/assets/stylesheets/books/lists.scss
+++ b/app/assets/stylesheets/books/lists.scss
@@ -16,6 +16,11 @@
 
     padding: 0;
     margin: 0;
+
+    h1 {
+      margin-left: 20px;
+      margin-bottom: 0px;
+    }
   }
 
   .filters {
@@ -30,8 +35,10 @@
   .filters li.filter {
     margin: 1rem 1rem;
 
-    h3 {
+    div {
       margin: 0.5rem 0;
+      font-size: 1.2em;
+      font-weight: bold;
     }
 
     ul {

--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -62,7 +62,7 @@ header {
     border-bottom: 1px solid #888;
   }
 
-  > h1 { font-size: 1em; margin: 0; text-align: left; padding: 0.6rem 1rem;
+  #library-title { font-size: 1em; margin: 0; text-align: left; padding: 0.6rem 1rem;
     border-bottom: 1px solid #888; text-shadow: #555 0px 1px 1px;
     font-weight: 100;
 
@@ -95,7 +95,7 @@ header {
       font-size: 0.65em;
     }
 
-    h1 { font-size: 1em; margin: 0; float: left;
+    #name-and-loans { font-size: 1em; margin: 0; float: left;
       a { text-decoration: none;
         .name { text-decoration: underline; }
         .loan_count { color: #000; }

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -31,7 +31,7 @@ module BooksHelper
 
   def formatted_version_changes(version)
     version.changeset.map { |key, (_old_value, new_value)|
-      tag.li do
+      tag.div do
         "#{key.capitalize}: #{tag.code { new_value.to_s }}".html_safe
       end
     }.join("").html_safe

--- a/app/views/books/_filters.html.erb
+++ b/app/views/books/_filters.html.erb
@@ -12,7 +12,7 @@
   </li>
   <li class="filter search-filter">
     <%= form_with url: "", method: :get do |form| %>
-      <%= form.label :book_reference, "Search for a book by copy ID", hidden: true %>
+      <%= form.label :book_reference, "Search book titles", hidden: true %>
       <%= form.text_field :q, value: params[:q], placeholder: "Search titles..." %>
       <%= form.submit "Search", class: "button btn" %>
     <% end %>

--- a/app/views/books/_filters.html.erb
+++ b/app/views/books/_filters.html.erb
@@ -1,6 +1,6 @@
 <ul class="filters">
   <li class="filter">
-    <h3>availability</h3>
+    <div>availability</div>
     <ul>
       <li><%= filter_link "available", :availability, "available" %></li>
       <% Location.all.each do |location| %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -2,6 +2,7 @@
   <%= render :partial => "filters" %>
 
   <div class="results">
+  <h1>Books</h1>
     <%= render :partial => "book_grid", :locals => { :books => @books } %>
   </div>
 </div>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -12,11 +12,11 @@
     <%= render :partial => "copies/copy", :collection => @book.copies.ordered_by_availability, locals: { link_to_copy: true } %>
   </ul>
 
-  <nav class="actions">
+  <div class="actions">
     <ul>
       <li><%= link_to "Edit this book's details", edit_book_path(@book) %></li>
       <li><%= link_to "Add another copy", new_book_copy_path(@book) %></li>
       <li><%= link_to "See revision history", history_book_path(@book) %></li>
     </ul>
-  </nav>
+  </div>
 </section>

--- a/app/views/copies/show.html.erb
+++ b/app/views/copies/show.html.erb
@@ -41,7 +41,7 @@
     </table>
   <% end %>
 
-  <nav class="actions">
+  <div class="actions">
     <ul>
       <li><%= link_to "See all copies of this book", book_path(@book) %></li>
       <li><%= link_to "Add another copy", new_book_copy_path(@book) %></li>
@@ -50,5 +50,5 @@
         <li><%= link_to "Report this copy as missing", missing_copy_path(@copy), method: :put %></li>
       <% end %>
     </ul>
-  </nav>
+  </div>
 </section>

--- a/app/views/copies/show.html.erb
+++ b/app/views/copies/show.html.erb
@@ -15,7 +15,7 @@
   </ul>
 
   <% if @previous_loans.any? %>
-    <h3>Loan history</h3>
+    <h2>Loan history</h2>
     <table class="history">
       <thead>
         <tr>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta charset="utf-8" />
   <title><%= library_title %></title>
   <%= stylesheet_link_tag    "application", :media => "all" %>
   <%= javascript_include_tag "application" %>
@@ -36,13 +37,14 @@
     <% end %>
   </header>
 
-  <% flash.each do |id, message| %>
-  <div class="flash flash_<%= id %> wrap">
-    <%= message %>
-  </div>
-  <% end %>
+  <main>
+    <% flash.each do |id, message| %>
+    <div class="flash flash_<%= id %> wrap">
+      <%= message %>
+    </div>
+    <% end %>
 
-  <%= yield %>
-
+    <%= yield %>
+  </main>
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
 <body>
 
   <header>
-    <h1><%= link_to library_title, root_path %></h1>
+    <span id="library-title"><%= link_to library_title, root_path %></span>
     <div class="clear"></div>
     <% if current_user %>
       <nav class="signed-in">
@@ -23,11 +23,11 @@
 
         <ul class="user">
           <li>
-            <h1>
+            <span id="name-and-loans">
             <%= link_to user_path(current_user) do %>
               <span class="name"><%= current_user.name %></span> <span class="loan_count">(<%= current_user.copies.count %>)</span>
             <% end %>
-            </h1>
+            </span>
           </li>
           <li><%= link_to "sign out", sign_out_path %></li>
         </ul>

--- a/test/controllers/books_controller_test.rb
+++ b/test/controllers/books_controller_test.rb
@@ -26,7 +26,7 @@ class BooksControllerTest < ActionDispatch::IntegrationTest
     it "shows all books" do
       get books_path
 
-      assert_select "h3", "availability"
+      assert_select "h1", "Books"
       assert_select "img", 4
     end
 

--- a/test/integration/copy_actions_test.rb
+++ b/test/integration/copy_actions_test.rb
@@ -138,7 +138,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
       it "displays a list of previous loans" do
         visit "/copy/53"
 
-        assert page.has_selector?("h3", text: "Loan history")
+        assert page.has_selector?("h2", text: "Loan history")
 
         rows = page.all("table.history tr").map { |r| r.all("th, td").map(&:text).map(&:strip) }
         assert_equal [


### PR DESCRIPTION
See individual commits for details, but this fixes most of the HTML issues that were highlighted by an automated accessibility checker. The forms to add a book and a copy are not passing the automated checks due to their use of lists - this can't be easily changed because the HTML that is failing is being generated by the formtastic gem.