### PR TITLE
Add `.git-blame-ignore-revs` file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Commit which added Sorbet
+798cf5544cf5add52d65ad0e26530362d2d6047c
+# Commit which removed Sorbet
+568c1892be466564a4e6e590663b6a7c76ade77a


### PR DESCRIPTION
The commit to add Sorbet type checking and then the commit to remove it each created a diff of around 125000 lines(!) which makes searching the repo history tricky. This adds a `.git-blame-ignore-revs` file to remove them from the git blame.