### PR TITLE
Stop using `book_reference` in the copies table - replace all uses with copy `id`

### DIFF
--- a/app/assets/javascripts/copies.js
+++ b/app/assets/javascripts/copies.js
@@ -1,7 +1,0 @@
-$( function() {
-
-  $('input#copy_book_reference').click( function() {
-    $(this).parents('fieldset.copy-number').find("input[type='radio']").prop('checked', true);
-  });
-
-})

--- a/app/assets/stylesheets/books.scss
+++ b/app/assets/stylesheets/books.scss
@@ -59,7 +59,7 @@ section.single_book {
   }
 
   h1 {
-    .book_reference { font-size: 1.1em; color: #888; font-weight: normal; }
+    .copy_id_number { font-size: 1.1em; color: #888; font-weight: normal; }
   }
 
   .cover { background: #444; min-height: 8em; text-align: center; padding: 1em 0;

--- a/app/assets/stylesheets/copies.scss
+++ b/app/assets/stylesheets/copies.scss
@@ -47,40 +47,6 @@
   }
 }
 
-fieldset.copy-number {
-  display: block;
-  padding: 1em;
-  background: #eee;
-  border-bottom: 1px solid #ccc;
-
-  label.copy-option-label {
-    display: block;
-    margin: 0.6em 0;
-    line-height: 1;
-
-    span {
-      display: inline-block;
-    }
-  }
-
-  input[type=radio] {
-    float: left;
-    margin-right: 1em;
-    line-height: 1;
-  }
-
-  li.input.numeric {
-    margin: 0 0 0 1.5em;
-    padding: 0.5em 0;
-
-    input {
-      width: 3em;
-      padding: 0.35em;
-      font-size: 1.2em;
-    }
-  }
-}
-
 fieldset.location {
   display: block;
   margin: 1.5em 0 0 0;

--- a/app/controllers/copies_controller.rb
+++ b/app/controllers/copies_controller.rb
@@ -10,17 +10,17 @@ class CopiesController < ApplicationController
   end
 
   def edit
-    @copy = Copy.find_by(book_reference: params[:id])
+    @copy = Copy.find_by(id: params[:id])
     @book = @copy.book
   end
 
   def lookup
-    @copy = Copy.find_by(book_reference: params[:book_reference])
+    @copy = Copy.find_by(id: params[:id])
 
     if @copy
       redirect_to copy_path(@copy)
     else
-      flash[:alert] = "Copy #{params[:book_reference]} couldn't be found."
+      flash[:alert] = "Copy #{params[:id]} couldn't be found."
       redirect_to root_path
     end
   end
@@ -28,12 +28,8 @@ class CopiesController < ApplicationController
   def create
     @copy = parent.copies.build(copy_params)
 
-    if params[:copy_has_id_number].blank?
-      @copy.book_reference = nil
-    end
-
     if @copy.save
-      flash[:notice] = "Copy #{@copy.book_reference} has been added to the library."
+      flash[:notice] = "Copy #{@copy.id} has been added to the library."
       redirect_to book_path(@copy.book)
     else
       render action: :new
@@ -41,7 +37,7 @@ class CopiesController < ApplicationController
   end
 
   def update
-    @copy = Copy.find_by(book_reference: params[:id])
+    @copy = Copy.find_by(id: params[:id])
     if @copy.update(params.require(:copy).permit(:location_id))
       flash[:notice] = "Location updated"
       redirect_to copy_path(@copy)
@@ -52,17 +48,17 @@ class CopiesController < ApplicationController
 
   def borrow
     if resource.borrow(current_user)
-      flash[:notice] = "Copy #{resource.book_reference} is now on loan to you."
+      flash[:notice] = "Copy #{resource.id} is now on loan to you."
     end
   rescue Copy::NotAvailable
-    flash[:alert] = "Copy #{resource.book_reference} is already on loan to #{resource.current_user.name}."
+    flash[:alert] = "Copy #{resource.id} is already on loan to #{resource.current_user.name}."
   ensure
     redirect_to copy_path(resource)
   end
 
   def return
     if resource.return(current_user, location)
-      msg = "Copy #{resource.book_reference} has now been returned"
+      msg = "Copy #{resource.id} has now been returned"
       if location
         msg << " to #{location}"
       end
@@ -70,20 +66,20 @@ class CopiesController < ApplicationController
       flash[:notice] = msg
     end
   rescue Copy::NotOnLoan
-    flash[:alert] = "Copy #{resource.book_reference} is not on loan."
+    flash[:alert] = "Copy #{resource.id} is not on loan."
   ensure
     redirect_to copy_path(resource)
   end
 
   def set_missing
     resource.set_missing
-    flash[:notice] = "Copy ##{resource.book_reference} has been marked as missing"
+    flash[:notice] = "Copy ##{resource.id} has been marked as missing"
     redirect_to copy_path(resource)
   end
 
   def unset_missing
     resource.unset_missing
-    flash[:notice] = "Copy ##{resource.book_reference} is no longer marked as missing"
+    flash[:notice] = "Copy ##{resource.id} is no longer marked as missing"
     redirect_to copy_path(resource)
   end
 
@@ -99,10 +95,10 @@ private
   end
 
   def resource
-    @copy = Copy.find_by(book_reference: params[:id]) || not_found
+    @copy = Copy.find_by(id: params[:id]) || not_found
   end
 
   def copy_params
-    params.require(:copy).permit(:book_id, :book_reference, :on_loan, :location_id)
+    params.require(:copy).permit(:id, :book_id, :on_loan, :location_id)
   end
 end

--- a/app/models/copy.rb
+++ b/app/models/copy.rb
@@ -4,8 +4,6 @@ class Copy < ApplicationRecord
   has_many :users, through: :loans
   belongs_to :location
 
-  validates :book_reference, presence: true, uniqueness: true
-
   before_validation :allocate_book_reference, on: :create, if: proc { |c| c.book_reference.blank? }
 
   scope :on_loan, -> { where(on_loan: true) }

--- a/app/models/copy.rb
+++ b/app/models/copy.rb
@@ -4,13 +4,11 @@ class Copy < ApplicationRecord
   has_many :users, through: :loans
   belongs_to :location
 
-  before_validation :allocate_book_reference, on: :create, if: proc { |c| c.book_reference.blank? }
-
   scope :on_loan, -> { where(on_loan: true) }
   scope :available, -> { where(on_loan: false) }
   scope :missing, -> { where(missing: true) }
 
-  scope :ordered_by_availability, -> { order("on_loan ASC, book_reference ASC") }
+  scope :ordered_by_availability, -> { order("on_loan ASC, id ASC") }
   scope :recently_added, -> { order("created_at DESC") }
 
   class NotAvailable < RuntimeError; end
@@ -69,17 +67,5 @@ class Copy < ApplicationRecord
 
   def unset_missing
     update(missing: false)
-  end
-
-  def allocate_book_reference
-    self.book_reference = Copy.next_available_book_reference
-  end
-
-  def to_param
-    book_reference.to_s
-  end
-
-  def self.next_available_book_reference
-    (Copy.order("book_reference desc nulls last").first || Copy.new).book_reference.to_i + 1
   end
 end

--- a/app/views/books/_filters.html.erb
+++ b/app/views/books/_filters.html.erb
@@ -12,7 +12,7 @@
   </li>
   <li class="filter search-filter">
     <%= form_with url: "", method: :get do |form| %>
-      <%= form.label :book_reference, "Search book titles", hidden: true %>
+      <%= form.label :copy_id, "Search book titles", hidden: true %>
       <%= form.text_field :q, value: params[:q], placeholder: "Search titles..." %>
       <%= form.submit "Search", class: "button btn" %>
     <% end %>

--- a/app/views/copies/_copy.html.erb
+++ b/app/views/copies/_copy.html.erb
@@ -1,7 +1,7 @@
 <li class="loan_status <%= copy.status.to_s %> <%= copy.current_user == current_user ? "my_copy" : "" %>
   <%= "missing" if copy.missing? %>">
   <% if local_assigns[:link_to_copy] %>
-    <h2><%= link_to "##{copy.book_reference}", copy_path(copy) %></h2>
+    <h2><%= link_to "##{copy.id}", copy_path(copy) %></h2>
   <% end %>
 
   <% if copy.on_loan? %>

--- a/app/views/copies/edit.html.erb
+++ b/app/views/copies/edit.html.erb
@@ -6,7 +6,7 @@
 
     <dl class='copy-number'>
       <dt>Copy number</dt>
-      <dd><%= @copy.book_reference %></dd>
+      <dd><%= @copy.id %></dd>
     </dl>
   </div>
 
@@ -24,4 +24,3 @@
     <% end %>
   <% end %>
 </section>
-

--- a/app/views/copies/new.html.erb
+++ b/app/views/copies/new.html.erb
@@ -2,26 +2,6 @@
   <h1>Add a new copy of <%= @book.title %></h1>
 
   <%= semantic_form_for [@book, @copy] do |f| %>
-    <h3>Does this copy already have an ID number?</h3>
-
-    <fieldset class="copy-number">
-      <label for="copy_has_id_number_true" class="copy-option-label">
-        <span>Yes, I've given it a number:</span>
-        <%= radio_button_tag "copy_has_id_number", "true", (params[:copy_has_id_number].present?) %>
-      </label>
-
-      <ul>
-        <%= f.input :book_reference, label: false, placeholder: Copy.next_available_book_reference.to_s %>
-      </ul>
-    </fieldset>
-
-    <fieldset class="copy-number">
-      <label for="copy_has_id_number_0" class="copy-option-label">
-        <span>No, generate one for me.</span>
-        <%= radio_button_tag "copy_has_id_number", "0", (params[:copy_has_id_number].blank?) %>
-      </label>
-    </fieldset>
-
     <fieldset class="location">
       <label for="location">
         <%= f.input :location, as: :select, collection: Location.all, include_blank: "unknown" %>
@@ -33,4 +13,3 @@
     <% end %>
   <% end %>
 </section>
-

--- a/app/views/copies/show.html.erb
+++ b/app/views/copies/show.html.erb
@@ -1,5 +1,5 @@
 <section class="single_book wrap">
-  <h1><span class="book_reference">#<%= @copy.book_reference %></span> <%= @book.title %></h1>
+  <h1><span class="copy_id_number">#<%= @copy.id %></span> <%= @book.title %></h1>
 
   <p style="text-align: center;"><%= book_cover_tag @book, :size => "S" %></p>
 

--- a/app/views/root/start.html.erb
+++ b/app/views/root/start.html.erb
@@ -9,8 +9,8 @@
       <h2>Find a copy</h2>
       <%= form_with url: lookup_copy_index_path, method: :post do |form| %>
         <p>
-          <%= form.label :book_reference, "Search for a book by copy ID", hidden: true %>
-          <%= form.text_field :book_reference, placeholder: "Enter a copy ID..." %>
+          <%= form.label :id, "Search for a book by copy ID", hidden: true %>
+          <%= form.text_field :id, placeholder: "Enter a copy ID..." %>
           <%= form.submit "Go", class: "btn" %>
         </p>
       <% end %>
@@ -40,7 +40,7 @@
     <h2>Recent loans</h2>
     <ul>
       <% @recent_loans.each do |loan| %>
-        <li><%= link_to loan.user.name, user_path(loan.user) %> borrowed <%= link_to "##{loan.copy.book_reference}: #{loan.book.title}", copy_path(loan.copy) %> <span class="timestamp"><%= distance_of_time_in_words_to_now loan.loan_date %> ago</span></li>
+        <li><%= link_to loan.user.name, user_path(loan.user) %> borrowed <%= link_to "##{loan.copy.id}: #{loan.book.title}", copy_path(loan.copy) %> <span class="timestamp"><%= distance_of_time_in_words_to_now loan.loan_date %> ago</span></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/user/_copy.html.erb
+++ b/app/views/user/_copy.html.erb
@@ -1,6 +1,6 @@
 <li class="loan_status with_link">
   <%= link_to book_path(copy.book) do %>
-    <h2>#<%= copy.book_reference %></h2>
+    <h2>#<%= copy.id %></h2>
     <p><%= copy.book.title %><span class="since">since <%= copy.current_loan.loan_date.strftime("%b %d, %Y") %></span></p>
   <% end %>
 </li>

--- a/app/views/user/_loan.html.erb
+++ b/app/views/user/_loan.html.erb
@@ -1,6 +1,6 @@
 <li class="loan_status with_link">
   <%= link_to book_path(loan.book) do %>
-    <h2>#<%= loan.copy.book_reference %></h2>
+    <h2>#<%= loan.copy.id %></h2>
     <p><%= loan.book.title %><span class="since">borrowed <%= loan.loan_date.strftime("%b %d, %Y") %><%= " &mdash; ".html_safe + loan.return_date.strftime("%b %d, %Y") if loan.return_date %></span></p>
   <% end %>
 </li>

--- a/db/migrate/20221029222254_make_book_reference_nullable.rb
+++ b/db/migrate/20221029222254_make_book_reference_nullable.rb
@@ -1,0 +1,5 @@
+class MakeBookReferenceNullable < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :copies, :book_reference, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_17_124354) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_29_222254) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -57,7 +57,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_17_124354) do
 
   create_table "copies", id: :serial, force: :cascade do |t|
     t.integer "book_id"
-    t.integer "book_reference", null: false
+    t.integer "book_reference"
     t.boolean "on_loan", default: false, null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false

--- a/test/integration/book_actions_test.rb
+++ b/test/integration/book_actions_test.rb
@@ -28,10 +28,13 @@ class BookActionsTest < ActionDispatch::IntegrationTest
         visit "/books/#{@book.id}"
 
         assert page.has_content?("1 copy")
+
+        copy_id = @book.copies.first.id
+
         within ".copies li" do
-          assert page.has_link?("#1", href: "/copy/1")
+          assert page.has_link?("##{copy_id}", href: "/copy/#{copy_id}")
           assert page.has_content?("Available to borrow")
-          assert page.has_link?("Borrow", href: "/copy/1/borrow")
+          assert page.has_link?("Borrow", href: "/copy/#{copy_id}/borrow")
         end
       end
 

--- a/test/integration/copy_actions_test.rb
+++ b/test/integration/copy_actions_test.rb
@@ -8,7 +8,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
 
     describe "given an available copy exists" do
       setup do
-        @copy = FactoryBot.create(:copy, book_reference: "123")
+        @copy = FactoryBot.create(:copy, id: "123")
       end
 
       it "renders the copy page" do
@@ -63,7 +63,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
 
     describe "given a copy is on loan to the signed in user" do
       setup do
-        @copy = FactoryBot.create(:copy, book_reference: "123")
+        @copy = FactoryBot.create(:copy, id: "123")
         @copy.borrow(signed_in_user)
       end
 
@@ -93,7 +93,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
     describe "given a copy is on loan to another user" do
       setup do
         @another_user = FactoryBot.create(:user, name: "O'Brien")
-        @copy = FactoryBot.create(:copy, book_reference: "123")
+        @copy = FactoryBot.create(:copy, id: "123")
         @copy.borrow(@another_user)
       end
 
@@ -123,7 +123,7 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
 
     describe "given a copy which has been borrowed multiple times" do
       setup do
-        @copy = FactoryBot.create(:copy, book_reference: "53")
+        @copy = FactoryBot.create(:copy, id: "53")
 
         @user1 = FactoryBot.create(:user, name: "Julia")
         @user2 = FactoryBot.create(:user, name: "Emmanuel Goldstein")

--- a/test/integration/start_page_test.rb
+++ b/test/integration/start_page_test.rb
@@ -23,12 +23,12 @@ class StartPageTest < ActionDispatch::IntegrationTest
     end
 
     it "allows the user to look up a valid copy by id" do
-      FactoryBot.create(:copy, book_reference: "123")
+      FactoryBot.create(:copy, id: "123")
 
       visit "/"
 
       within ".copy-lookup" do
-        fill_in "book_reference", with: "123"
+        fill_in "id", with: "123"
         click_on "Go"
       end
 
@@ -39,7 +39,7 @@ class StartPageTest < ActionDispatch::IntegrationTest
       visit "/"
 
       within ".copy-lookup" do
-        fill_in "book_reference", with: "999"
+        fill_in "id", with: "999"
         click_on "Go"
       end
 
@@ -50,7 +50,7 @@ class StartPageTest < ActionDispatch::IntegrationTest
     it "displays recently added copies added to the library" do
       @book = FactoryBot.create(:book, title: "The Lion, the Witch and the Wardrobe")
       @older_copies = FactoryBot.create_list(:copy, 10)
-      @copy = FactoryBot.create(:copy, book_reference: "123", book: @book)
+      @copy = FactoryBot.create(:copy, id: "123", book: @book)
 
       visit "/"
       within ".recently-added" do
@@ -68,9 +68,9 @@ class StartPageTest < ActionDispatch::IntegrationTest
       within ".recent-activity ul" do
         copies_on_loan.reverse.each_with_index do |copy, i|
           within "li:nth-of-type(#{i + 1})" do
-            assert page.has_content?("#{copy.current_user.name} borrowed ##{copy.book_reference}: #{copy.book.title}")
+            assert page.has_content?("#{copy.current_user.name} borrowed ##{copy.id}: #{copy.book.title}")
             assert page.has_selector?("a[href='/user/#{copy.current_user.id}']")
-            assert page.has_selector?("a[href='/copy/#{copy.book_reference}']")
+            assert page.has_selector?("a[href='/copy/#{copy.id}']")
           end
         end
       end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -7,9 +7,11 @@ class ActionDispatch::IntegrationTest
 
   before do
     prepare_omniauth_for_testing
+    DatabaseCleaner.start
   end
 
   after do
     Capybara.use_default_driver
+    DatabaseCleaner.clean
   end
 end

--- a/test/models/copy_test.rb
+++ b/test/models/copy_test.rb
@@ -21,14 +21,6 @@ describe Copy do
       assert_equal 3, third_copy.book_reference
     end
 
-    it "does not allow duplicate book references" do
-      first_copy = @book.copies.create!(book_reference: 30)
-      second_copy = @book.copies.build(book_reference: 30)
-
-      assert_equal 30, first_copy.book_reference
-      assert_not second_copy.valid?
-    end
-
     it "sets on_loan to false by default" do
       copy = @book.copies.create!
 

--- a/test/models/copy_test.rb
+++ b/test/models/copy_test.rb
@@ -5,22 +5,7 @@ describe Copy do
     @book = FactoryBot.create(:book)
   end
 
-  it "returns the book reference as the url parameter" do
-    copy = FactoryBot.create(:copy, book_reference: "123")
-    assert_equal "123", copy.to_param
-  end
-
   describe "creating a new copy" do
-    it "increments the book reference" do
-      first_copy = @book.copies.first # already created on book creation
-      second_copy = @book.copies.create!(book_reference: 2)
-      third_copy = @book.copies.create!
-
-      assert_equal 1, first_copy.book_reference
-      assert_equal 2, second_copy.book_reference
-      assert_equal 3, third_copy.book_reference
-    end
-
     it "sets on_loan to false by default" do
       copy = @book.copies.create!
 
@@ -137,11 +122,11 @@ describe Copy do
       # delete first auto-generated copy of book
       @book.copies.delete_all
 
-      FactoryBot.create(:copy, book_reference: 101, book: @book)
-      FactoryBot.create(:copy, book_reference: 201, book: @book)
-      FactoryBot.create(:copy, book_reference: 301, book: @book)
-      assert_equal 301, Copy.recently_added.first.book_reference
-      assert_equal 101, Copy.recently_added.last.book_reference
+      FactoryBot.create(:copy, id: 101, book: @book)
+      FactoryBot.create(:copy, id: 201, book: @book)
+      FactoryBot.create(:copy, id: 301, book: @book)
+      assert_equal 301, Copy.recently_added.first.id
+      assert_equal 101, Copy.recently_added.last.id
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,6 @@ require "mocha/minitest"
 Dir[Rails.root.join("test/support/*.rb")].sort.each { |f| require f }
 
 DatabaseCleaner.strategy = :transaction
-DatabaseCleaner.clean
 
 class ActiveSupport::TestCase
   ActiveRecord::Migration.check_pending!


### PR DESCRIPTION
This PR stops using `book_reference` from the copies table and instead uses the copy `id` everywhere instead. Both the `book_reference` and the `id` are unique to a copy, so provide a unique way to identify it. The `book_reference` is used when searching and in URLs, but this could be done by the copy `id` instead. Having two unique numbers per copy is unnecessary and can be confusing because it's not always clear where and how each number is used.

The `book_reference` is the number written in the physical books. As part one of this work I have rewritten the data in the copies table so that the copy `id` for each copy now matches its `book_reference`. This means that the numbers written in each book in the library can stay the same.

Once this is merged, the `book_reference` column will be null for any new copies. It can be dropped later.