### PR TITLE
Stop concurrent test runs on GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,8 @@ name: Run tests
 
 on: [push, pull_request]
 
+concurrency: tests
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/test/integration/start_page_test.rb
+++ b/test/integration/start_page_test.rb
@@ -50,13 +50,12 @@ class StartPageTest < ActionDispatch::IntegrationTest
     it "displays recently added copies added to the library" do
       @book = FactoryBot.create(:book, title: "The Lion, the Witch and the Wardrobe")
       @older_copies = FactoryBot.create_list(:copy, 10)
-      @copy = FactoryBot.create(:copy, id: "123", book: @book)
-
+      @copy = FactoryBot.create(:copy, id: "12345", book: @book)
       visit "/"
       within ".recently-added" do
         within "li:first" do
           assert page.has_selector?("img[alt^='The Lion, the Witch and the Wardrobe']")
-          assert page.has_selector?("a[href='/copy/123']")
+          assert page.has_selector?("a[href='/copy/12345']")
         end
       end
     end


### PR DESCRIPTION
There have been some cases where dependabot has opened a PR and two lots of tests have been running at the same since both a push and a pull request trigger the tests. We only want one set of tests to be running at once.