### PR TITLE
Minor changes to user page

### DIFF
--- a/app/views/user/show.html.erb
+++ b/app/views/user/show.html.erb
@@ -1,13 +1,22 @@
 <section class="user wrap">
   <h1><%= @user.name.possessive %> Books</h1>
 
-  <ul class="copies">
-    <%= render :partial => "copy", :collection => @user.current_copies %>
-  </ul>
+  <% if @user.current_copies.any? %>
+    <h2>Current loans</h2>
 
-  <h2>Previous loans</h2>
+    <ul class="copies">
+      <%= render partial: "copy", collection: @user.current_copies %>
+    </ul>
+  <% end %>
 
-  <ul class="copies">
-    <%= render :partial => "loan", :collection => @user.previous_loans %>
-  </ul>
+
+  <% if @user.previous_loans.any? %>
+    <h2>Previous loans</h2>
+
+    <ul class="copies">
+      <%= render partial: "loan", collection: @user.previous_loans %>
+    </ul>
+  <% else %>
+    <p>No previous loans</p>
+  <% end %>
 </section>

--- a/test/controllers/user_controller_test.rb
+++ b/test/controllers/user_controller_test.rb
@@ -3,14 +3,32 @@ require "integration_test_helper"
 class UserControllerTest < ActionDispatch::IntegrationTest
   before do
     sign_in_user
+    @user = User.find_by(email: "stub.user@example.org")
   end
 
   it "gets the user page" do
-    my_user = User.find_by(email: "stub.user@example.org")
-
-    get user_url(my_user.id)
+    get user_url(@user.id)
 
     assert_response :success
-    assert_match(/Stub User’s Books/, @response.body)
+    assert_select "h1", "#{@user.name}’s Books"
+    assert_select "p", "No previous loans"
+  end
+
+  it "shows the current loans" do
+    loan = FactoryBot.create(:loan, user: @user)
+
+    get user_url(@user.id)
+
+    assert_select "h2", "Current loans"
+    assert_select "section li", /#{loan.copy.book.title}/
+  end
+
+  it "shows the previous loans" do
+    loan = FactoryBot.create(:loan, user: @user, state: "returned")
+
+    get user_url(@user.id)
+
+    assert_select "h2", "Previous loans"
+    assert_select "section li", /#{loan.copy.book.title}/
   end
 end


### PR DESCRIPTION
This makes a few minor changes to the user page so that we
- show a message if there are no previous loans
- adds a "Current loans" heading to match the "Previous loans" heading
- don't have empty `<ul>` elements - we now only show `<ul>` containing a `<li>`