### PR TITLE
Fix searching for a book by title on the homepage

### DIFF
--- a/app/views/root/start.html.erb
+++ b/app/views/root/start.html.erb
@@ -20,8 +20,8 @@
       <h2>Search books by title</h2>
       <%= form_with url: books_path, method: :get do |form| %>
         <p>
-          <%= form.label :q, "Search for a book by title", hidden: true %>
-          <%= form.text_field :q, placeholder: "Search titles..." %>
+          <%= form.label :query, "Search for a book by title", hidden: true %>
+          <%= form.text_field :query, placeholder: "Search titles..." %>
           <%= form.submit "Go", class: "btn" %>
         </p>
       <% end %>

--- a/test/integration/start_page_test.rb
+++ b/test/integration/start_page_test.rb
@@ -47,6 +47,22 @@ class StartPageTest < ActionDispatch::IntegrationTest
       assert page.has_content?("Copy 999 couldn't be found")
     end
 
+    it "allows the user to look up a book by title" do
+      FactoryBot.create(:book, title: "first title")
+      FactoryBot.create(:book, title: "second title")
+      FactoryBot.create(:book, title: "third title")
+
+      visit "/"
+
+      within ".title-lookup" do
+        fill_in "query", with: "first"
+        click_on "Go"
+      end
+
+      assert_equal "/books", current_path
+      assert_equal 1, page.find_all("img").length
+    end
+
     it "displays recently added copies added to the library" do
       @book = FactoryBot.create(:book, title: "The Lion, the Witch and the Wardrobe")
       @older_copies = FactoryBot.create_list(:copy, 10)


### PR DESCRIPTION
Searching for a book by title from the homepage wasn't working and was returning all books. This broke in d6233e8 when the Books controller started expecting the query string to be named "query" instead of "q" and the start page wasn't updated to match the change.