### PR TITLE
Stop storing the `image_url` for a user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,6 @@ class User < ApplicationRecord
   def self.atts_from_auth_hash(hash)
     {
       name: hash[:info][:name],
-      image_url: hash[:info][:image],
       provider: hash[:provider],
       provider_uid: hash[:uid],
     }

--- a/db/migrate/20230503150032_remove_image_url_from_users.rb
+++ b/db/migrate/20230503150032_remove_image_url_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveImageUrlFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :image_url, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_30_145558) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_03_150032) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -88,7 +88,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_30_145558) do
     t.string "email", limit: 255
     t.string "provider", limit: 255
     t.string "provider_uid", limit: 255
-    t.text "image_url"
   end
 
   create_table "versions", id: :serial, force: :cascade do |t|

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -6,8 +6,5 @@ FactoryBot.define do
     end
     provider { "google" }
     sequence(:provider_uid)
-    sequence(:image_url) do |n|
-      "https://example.org/users/#{n}.jpg"
-    end
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -42,7 +42,6 @@ describe User do
     assert_equal "stub.user@example.org", user.email
     assert_equal "google", user.provider
     assert_equal "12345", user.provider_uid
-    assert_equal "https://example.org/image.jpg", user.image_url
   end
 
   it "can be found from a matching email" do


### PR DESCRIPTION
We had a column in the users table for the `image_url` - the url of their Google profile picture. This has never been used and we have no plans to use it, so removing it means that we are storing a little less personal data.